### PR TITLE
Files/v3

### DIFF
--- a/core/src/main/scala/quasar/destination/snowflake/Flow.scala
+++ b/core/src/main/scala/quasar/destination/snowflake/Flow.scala
@@ -17,7 +17,6 @@
 package quasar.destination.snowflake
 
 import slamdata.Predef._
-import scala.Predef.classOf
 
 import quasar.api.{Column, ColumnType}
 import quasar.api.push.OffsetKey
@@ -31,13 +30,9 @@ import cats.effect._
 import cats.implicits._
 
 import doobie._
-import doobie.free.connection.unwrap
-import doobie.implicits._
 
 import fs2.{Stream, Pipe}
 import fs2.concurrent.Queue
-
-import net.snowflake.client.jdbc.SnowflakeConnection
 
 import org.slf4s.Logger
 

--- a/core/src/main/scala/quasar/destination/snowflake/SnowflakeConfig.scala
+++ b/core/src/main/scala/quasar/destination/snowflake/SnowflakeConfig.scala
@@ -60,7 +60,7 @@ object SnowflakeConfig {
   val DefaultMaxReattempts = 10
   val SnowflakeUriSchema = "jdbc:snowflake"
   val SnowflakeDomain = "snowflakecomputing.com"
-  val DefaultStagingFileSize = 512
+  val DefaultStagingFileSize = 4096
 
   implicit val snowflakeConfigCodecJson: CodecJson[SnowflakeConfig] =
     casecodec11(SnowflakeConfig.apply, SnowflakeConfig.unapply)(

--- a/core/src/main/scala/quasar/destination/snowflake/SnowflakeDestination.scala
+++ b/core/src/main/scala/quasar/destination/snowflake/SnowflakeDestination.scala
@@ -50,7 +50,7 @@ final class SnowflakeDestination[F[_]: ConcurrentEffect: MonadResourceErr: Timer
   def destinationType: DestinationType =
     SnowflakeDestinationModule.destinationType
 
-  def tableBuilder(args: Flow.Args, xa: Transactor[F], logger: Logger): Resource[F, TempTable.Builder[F]] = {
+  def tableBuilder(args: Flow.Args, rxa: Resource[F, Transactor[F]], logger: Logger): Resource[F, TempTable.Builder[F]] = {
     val stagingParams = StageFile.Params(
       maxRetries = maxRetries,
       timeout = retryTimeout,
@@ -63,7 +63,7 @@ final class SnowflakeDestination[F[_]: ConcurrentEffect: MonadResourceErr: Timer
       Retry[F](maxRetries, retryTimeout),
       args,
       stagingParams,
-      xa,
+      rxa,
       logger))
   }
 

--- a/core/src/main/scala/quasar/destination/snowflake/StageFile.scala
+++ b/core/src/main/scala/quasar/destination/snowflake/StageFile.scala
@@ -20,16 +20,13 @@ import scala.Predef.classOf
 import slamdata.Predef._
 
 import cats.effect._
-import cats.effect.concurrent.Ref
 import cats.implicits._
 
 import doobie._
 import doobie.implicits._
 import doobie.free.connection.unwrap
 
-import fs2.{Chunk, Pipe, Pull, Stream}
-import fs2.concurrent.{NoneTerminatedQueue, Queue}
-import fs2.io
+import fs2.{Pipe, Pull, Stream}
 import fs2.io.file
 import fs2.io.file.WriteCursor
 
@@ -59,10 +56,8 @@ object StageFile {
       logger: Logger)
       : Resource[F, StageFile] = {
 
-    def inputStream = {
-      println(s"input : $input")
+    def inputStream =
       Files.newInputStream(input)
-    }
 
     val debug = (s: String) => Sync[F].delay(logger.debug(s))
 

--- a/core/src/main/scala/quasar/destination/snowflake/StageFile.scala
+++ b/core/src/main/scala/quasar/destination/snowflake/StageFile.scala
@@ -16,6 +16,7 @@
 
 package quasar.destination.snowflake
 
+import scala.Predef.classOf
 import slamdata.Predef._
 
 import cats.effect._
@@ -24,11 +25,15 @@ import cats.implicits._
 
 import doobie._
 import doobie.implicits._
+import doobie.free.connection.unwrap
 
 import fs2.{Chunk, Pipe, Pull, Stream}
 import fs2.concurrent.{NoneTerminatedQueue, Queue}
 import fs2.io
+import fs2.io.file
+import fs2.io.file.WriteCursor
 
+import java.nio.file._
 import java.util.UUID
 import net.snowflake.client.jdbc.SnowflakeConnection
 import scala.concurrent.duration._
@@ -47,13 +52,18 @@ object StageFile {
       timeout: FiniteDuration,
       maxFileSize: Int)
 
-  def apply[F[_]: ConcurrentEffect: ContextShift](
-      input: Stream[F, Byte],
-      connection: SnowflakeConnection,
+  def fromPath[F[_]: ConcurrentEffect: ContextShift](
+      input: Path,
       blocker: Blocker,
-      xa: Transactor[F],
+      rxa: Resource[F, Transactor[F]],
       logger: Logger)
       : Resource[F, StageFile] = {
+
+    def inputStream = {
+      println(s"input : $input")
+      Files.newInputStream(input)
+    }
+
     val debug = (s: String) => Sync[F].delay(logger.debug(s))
 
     val acquire: F[StageFile] = for {
@@ -63,75 +73,60 @@ object StageFile {
       def name = uniqueName
     }
 
-    def ingest(sf: StageFile): F[StageFile] =
-      io.toInputStreamResource(input) use { inputStream =>
-        for {
-          _ <- debug(s"Starting staging to file: @~/${sf.name}")
-          _ <- blocker.delay[F, Unit](connection.uploadStream("@~", "/", inputStream, sf.name, Compressed))
-          _ <- debug(s"Finished staging to file: @~/${sf.name}")
-        } yield sf
-      }
+    def ingest(sf: StageFile): F[StageFile] = rxa use { xa =>
+      for {
+        connection <- unwrap(classOf[SnowflakeConnection]).transact(xa)
+        _ <- debug(s"Starting staging to file: @~/${sf.name}")
+        _ <- blocker.delay[F, Unit](connection.uploadStream("@~", "/", inputStream, sf.name, Compressed))
+        _ <- debug(s"Finished staging to file: @~/${sf.name}")
+      } yield sf
+    }
 
-    val release: StageFile => F[Unit] = sf => Sync[F].defer {
+    val release: StageFile => F[Unit] = sf => Sync[F].defer { rxa.use { xa =>
       val fragment = fr"rm" ++ sf.fragment
       debug(s"Cleaning staging file @~/${sf.name} up") >>
       fragment.query[Unit].option.void.transact(xa)
-    }
+    }}
 
     Resource.make(acquire)(release).evalMap(ingest(_))
   }
 
   def retryable[F[_]: ConcurrentEffect: ContextShift: Timer](
-      input: Stream[F, Byte],
-      connection: SnowflakeConnection,
+      input: Path,
       blocker: Blocker,
-      xa: Transactor[F],
+      xa: Resource[F, Transactor[F]],
       logger: Logger,
       tried: Int,
       params: Params)
-      : Resource[F, StageFile] = for {
-    // First we need two copies of input stream
-    // one because on error in `StageFile` the stream is terminated
-    direct <- Resource.eval(Queue.noneTerminated[F, Chunk[Byte]])
-    // one to reuse it on error
-    fallback <- Resource.eval(Queue.noneTerminated[F, Chunk[Byte]])
-    // Then, since we don't want input stream to terminate but put all its data
-    // into both `direct` and `fallback` we need to `spawn` the stream
-    // the fiber will be joined in this resource finalizer.
-    _ <- input
-      .chunks
-      .evalTap(x => direct.enqueue1(Some(x)) >> fallback.enqueue1(Some(x)))
-      .onFinalize(direct.enqueue1(None) >> fallback.enqueue1(None))
-      .spawn
-      .compile
-      .resource
-      .lastOrError
-
-    res <-
-      StageFile[F](direct.dequeue.flatMap(Stream.chunk), connection, blocker, xa, logger).attempt flatMap {
-        case Left(_) if params.maxRetries > tried =>
-          Resource.eval(Timer[F].sleep(params.timeout)) >>
-          retryable(fallback.dequeue.flatMap(Stream.chunk), connection, blocker, xa, logger, tried + 1, params)
-        case Left(e) =>
-          Resource.eval(Sync[F].raiseError(e))
-        case Right(a) =>
-          a.pure[Resource[F, *]]
-      }
-
-  } yield res
+      : Resource[F, StageFile] =
+    StageFile.fromPath(input, blocker, xa, logger).attempt flatMap {
+      case Left(_) if params.maxRetries > tried =>
+        Resource.eval(Timer[F].sleep(params.timeout)) >>
+        retryable(input, blocker, xa, logger, tried + 1, params)
+      case Left(e) =>
+        Resource.eval(Sync[F].raiseError(e))
+      case Right(a) =>
+        a.pure[Resource[F, *]]
+    }
 
   // It would be much clearer if we could use `_.flatMap(Stream.resourceWeak(StageFile(...)))`
   // and then `files.compile.resource.toList` but the second finalizes resources before `eval`
   def files[F[_]: ConcurrentEffect: ContextShift: Timer](
       in: Stream[F, Byte],
-      connection: SnowflakeConnection,
       blocker: Blocker,
-      xa: Transactor[F],
+      xa: Resource[F, Transactor[F]],
       logger: Logger,
       params: Params)
       : Resource[F, List[StageFile]] = {
-    val resources = in.through(split(params.maxFileSize * 1024L * 1024L))
-      .map(retryable(_, connection, blocker, xa, logger, 0, params))
+    val resources = in.through(filePipe(params.maxFileSize * 1024L * 1024L, blocker))
+      .map { p =>
+        retryable(p, blocker, xa, logger, 0, params).evalTap({ _ =>
+          file.delete[F](blocker, p)
+        }).handleErrorWith({e => Resource.eval {
+          file.delete[F](blocker, p).attempt >>
+          Sync[F].raiseError(e)
+        }})
+      }
 
     def go(inp: Stream[F, Resource[F, StageFile]], acc: Resource[F, List[StageFile]])
         : Pull[F, Resource[F, List[StageFile]], Unit] = inp.pull.uncons1 flatMap {
@@ -148,58 +143,32 @@ object StageFile {
     }
   }
 
-  val Max = 128 * 1024L * 1024L
-
-  private def split[F[_]: ConcurrentEffect: ContextShift, A](
-      max: Long)
-      : Pipe[F, A, Stream[F, A]] = in => Stream.force {
-    for {
-      q <- Queue.noneTerminated[F, Stream[F, A]]
-      elqRef <- Ref.of[F, Option[NoneTerminatedQueue[F, Chunk[A]]]](None)
-      size <- Ref.of[F, Long](0L)
-    } yield {
-      def fin = Sync[F].defer {
-        q.enqueue1(none[Stream[F, A]]) >>
-        elqRef.get.flatMap {
-          case None =>
-            ().pure[F]
-          case Some(elq) =>
-            elq.enqueue1(none[Chunk[A]])
-        } >>
-        size.set(0L)
-      }
-
-      q.dequeue concurrently {
-        def go(inp: Stream[F, A]): Pull[F, Unit, Unit] = inp.pull.uncons flatMap {
-          case None =>
-            Pull.eval(fin) >> Pull.done
-          case Some((chunk, tail)) =>
-            def startStream: F[Unit] = for {
-              elq <- Queue.noneTerminated[F, Chunk[A]]
-              _ <- elqRef.set(elq.some)
-              _ <- q.enqueue1(elq.dequeue.flatMap(Stream.chunk).some)
-              _ <- elq.enqueue1(chunk.some)
-              _ <- size.set(chunk.size.toLong)
-            } yield ()
-            val action: F[Unit] =
-              elqRef.get flatMap {
-                case None =>
-                  startStream
-                case Some(elq) => for {
-                  currentSize <- size.get
-                  _ <- if (currentSize > max) {
-                    startStream >>
-                    elq.enqueue1(none[Chunk[A]])
-                  } else {
-                    elq.enqueue1(chunk.some) >>
-                    size.set(currentSize + chunk.size.toLong)
-                  }
-                } yield ()
-              }
-            Pull.eval(action) >> go(tail)
-          }
-        go(in).stream
-      }
+  private def filePipe[F[_]: ConcurrentEffect: ContextShift](
+      max: Long,
+      blocker: Blocker)
+      : Pipe[F, Byte, Path] = {
+    def go(inp: Stream[F, Byte], currentFile: Path, cursor: WriteCursor[F], size: Long)
+        : Pull[F, Path, Unit] = if (size > max) {
+      for {
+        newFile <- Pull.eval(blocker.delay[F, Path](Files.createTempFile("sf-", ".tmp")))
+        mbCursor <- Stream.resourceWeak(WriteCursor.fromPath[F](newFile, blocker)).pull.peek1
+        _ <- Pull.output1(currentFile.toAbsolutePath)
+        res <- go(inp, newFile, mbCursor.get._1, 0L)
+      } yield res
+    } else inp.pull.uncons.flatMap {
+      case None =>
+        Pull.output1(currentFile.toAbsolutePath) >>
+        Pull.done
+      case Some((chunk, tail)) =>
+        cursor.writePull(chunk).flatMap { newCursor =>
+          go(tail, currentFile, newCursor, chunk.size.toLong + size)
+        }
     }
+
+    in => for {
+      initFile <- Stream.eval(blocker.delay[F, Path](Files.createTempFile("sf-", ".tmp")))
+      cursor <- Stream.resource(WriteCursor.fromPath[F](initFile, blocker))
+      res <- go(in, initFile, cursor, 0L).stream
+    } yield res
   }
 }

--- a/core/src/main/scala/quasar/destination/snowflake/StageFile.scala
+++ b/core/src/main/scala/quasar/destination/snowflake/StageFile.scala
@@ -146,9 +146,9 @@ object StageFile {
         : Pull[F, Path, Unit] = if (size > max) {
       for {
         newFile <- Pull.eval(blocker.delay[F, Path](Files.createTempFile("sf-", ".tmp")))
-        mbCursor <- Stream.resourceWeak(WriteCursor.fromPath[F](newFile, blocker)).pull.peek1
+        cursor <- Stream.resourceWeak(WriteCursor.fromPath[F](newFile, blocker)).pull.lastOrError
         _ <- Pull.output1(currentFile.toAbsolutePath)
-        res <- go(inp, newFile, mbCursor.get._1, 0L)
+        res <- go(inp, newFile, cursor, 0L)
       } yield res
     } else inp.pull.uncons.flatMap {
       case None =>

--- a/core/src/main/scala/quasar/destination/snowflake/TempTable.scala
+++ b/core/src/main/scala/quasar/destination/snowflake/TempTable.scala
@@ -47,7 +47,7 @@ sealed trait TempTable[F[_]] {
 
 object TempTable {
   sealed trait Builder[F[_]] {
-    def build(connection: SnowflakeConnection, blocker: Blocker): Resource[F, TempTable[F]]
+    def build(blocker: Blocker): Resource[F, TempTable[F]]
   }
 
   def builder[F[_]: ConcurrentEffect: ContextShift: Timer: MonadResourceErr](
@@ -57,7 +57,7 @@ object TempTable {
       retry: ConnectionIO ~> ConnectionIO,
       args: Flow.Args,
       stagingParams: StageFile.Params,
-      xa: Transactor[F],
+      rxa: Resource[F, Transactor[F]],
       logger: Logger)
       : F[Builder[F]] = {
     val log = Slf4sLogHandler(logger)
@@ -72,13 +72,13 @@ object TempTable {
         fragment.queryWithLogHandler[Int](log).option.map(_.exists(_ === 1))
 
       writeMode match {
-        case WriteMode.Create => existing.transact(xa) flatMap { exists =>
+        case WriteMode.Create => rxa use { xa => existing.transact(xa) flatMap { exists =>
           MonadResourceErr[F].raiseError(
             ResourceError.accessDenied(
               args.path,
               "Create mode is set but table exists already".some,
               none)).whenA(exists)
-        }
+        }}
         case _ =>
           ().pure[F]
       }
@@ -116,10 +116,8 @@ object TempTable {
         retry(fr.updateWithLogHandler(log).run.void)
       }
 
-      def execFragment: Fragment => F[Unit] =
-        runFragment andThen (_.transact(xa))
 
-      def build(connection: SnowflakeConnection, blocker: Blocker): Resource[F, TempTable[F]] = {
+      def build(blocker: Blocker): Resource[F, TempTable[F]] = rxa flatMap { xa =>
         val createFragment = {
           val prefix =
             if (writeMode === WriteMode.Replace)
@@ -132,6 +130,9 @@ object TempTable {
           createColumnFragment
        }
 
+        def execFragment: Fragment => F[Unit] =
+          runFragment andThen (_.transact(xa))
+
         val dropFragment =
           fr"DROP TABLE IF EXISTS" ++ tmpFragment
 
@@ -140,7 +141,7 @@ object TempTable {
 
             def ingest[A]: Pipe[F, Region[F, A], A] = _.flatMap { (region: Region[F, A]) =>
               val nestedStream = Stream.force {
-                StageFile.files(region.data, connection, blocker, xa, logger, stagingParams) use { sfs =>
+                StageFile.files(region.data, blocker, rxa, logger, stagingParams) use { sfs =>
                   for {
                     size <- region.commitCount
                     _ <-  {

--- a/core/src/main/scala/quasar/destination/snowflake/TempTable.scala
+++ b/core/src/main/scala/quasar/destination/snowflake/TempTable.scala
@@ -39,8 +39,6 @@ import fs2.{Pipe, Stream}
 
 import org.slf4s.Logger
 
-import net.snowflake.client.jdbc.SnowflakeConnection
-
 sealed trait TempTable[F[_]] {
   def ingest[A]: Pipe[F, Region[F, A], A]
 }

--- a/core/src/test/scala/quasar/destination/snowflake/SnowflakeDestinationSpec.scala
+++ b/core/src/test/scala/quasar/destination/snowflake/SnowflakeDestinationSpec.scala
@@ -82,6 +82,7 @@ object SnowflakeDestinationSpec extends EffectfulQSpec[IO] with CsvSupport {
     Account.isEmpty || Password.isEmpty || User.isEmpty || Database.isEmpty || Schema.isEmpty || Warehouse.isEmpty
 
   skipAllIf(shouldSkip)
+
   "initialization" should {
     "fail with malformed config when not decodable" >>* {
       val cfg = Json("malformed" := true)


### PR DESCRIPTION
Snapshot `20.1.5-2c1f58e`

Fixes #249

I'm not totally sure if transactor should be initialized for every staged file, but this should save staging from `connection has been closed` for sure. Also file sizes are enlarged to 4Gb, no RAM restriction anymore. 

I didn't make file writes stopped by time (i.e. if there is no data for 20 minutes, finalize the file write, emit the `Path` and wait for new data chunk), can add this if waiting become a problem or you think that this is necessary. 
